### PR TITLE
Remove volume boost

### DIFF
--- a/reDIP-SID/i2s_init_data.hex
+++ b/reDIP-SID/i2s_init_data.hex
@@ -63,8 +63,6 @@
 //01 16 00 4f // 9.5dB gain at 115Hz
 //01 18 00 3B // 3dB gain at 330Hz
 
-
-00 22 00 00 // 12dB volume boost
 00 24 00 27 // unmute
 00 10 3c 3c // 0dB DAC Volume
 00 0e 02 00 // Enable volume ramp


### PR DESCRIPTION
Initially this was added to compensate for the room you were using for filters, which you've done differently now. With this change we might be a few dB quieter than a real SID but it's better than being overblown like we currently are.